### PR TITLE
Logger auto-add string

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -19,9 +19,11 @@ struct Logger
     Logger(bool doEndLine)
     {
         endLine = doEndLine;
+        between = "";
     }
     Logger(std::string inBetween)
     {
+        endLine = false;
         between = inBetween;
     }
     Logger(bool doEndLine, std::string inBetween)


### PR DESCRIPTION
Logger can now auto-add a string from the second/first parameter. It gets added to the end of each `<<`.